### PR TITLE
Noted the correct "Solr path" setting to use

### DIFF
--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -25,6 +25,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
     * Use the "http" protocol
     * The "solr host" should be `ddev-<projectname>-solr` **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
+    * The "solr path" should be set to "/" otherwise the web service won't be able to connect to the Solr service.
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
 * Download the config.zip provided on /admin/config/search/search-api/server/dev
 * Unzip the config.zip into .ddev/solr/conf. For example, `cd .ddev/solr/conf && unzip ~/Downloads/solr_8.x-config.zip`

--- a/docs/users/extend/additional-services.md
+++ b/docs/users/extend/additional-services.md
@@ -25,7 +25,7 @@ This recipe adds an Apache Solr container to a project. It will set up a solr co
     * Use the "http" protocol
     * The "solr host" should be `ddev-<projectname>-solr` **NOT the default "localhost"**, because it does not run in the same container as the webserver. (Note that just using "solr" will often work, and used to be recommended, but it can be ambiguous if there are more than one projects running with a solr service.)
     * The "solr core" should be named "dev" unless you customize the docker-compose.solr.yaml
-    * The "solr path" should be set to "/" otherwise the web service won't be able to connect to the Solr service.
+    * Systems that use the Solr API v1 should use the "solr path" value of "/solr", while systems that use the Solr API v2 should use "/", otherwise they won't be able to connect to the Solr server.
     * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`
 * Download the config.zip provided on /admin/config/search/search-api/server/dev
 * Unzip the config.zip into .ddev/solr/conf. For example, `cd .ddev/solr/conf && unzip ~/Downloads/solr_8.x-config.zip`


### PR DESCRIPTION
## The Problem/Issue/Bug:
The default "Solr path" value from Search API Solr is incorrect, it defaults to "/solr", which doesn't work.

## How this PR Solves The Problem:
This recommends setting the "Solr path" to just "/".

## Manual Testing Instructions:
Set up Solr 7.
